### PR TITLE
Add oneMKL info to project-ci-documentation.md

### DIFF
--- a/project-infrastructure/project-ci-documentation.md
+++ b/project-infrastructure/project-ci-documentation.md
@@ -164,7 +164,7 @@ Support contact for CI: [Alexey Srednitsky](https://github.com/toxicscum)
 | Instruction set architecture | Hardware Vendor | Processor Type | Operating System | Comment |
 | --- | --- | --- | --- | --- |
 | x86 | Intel/AMD | CPU | Ubuntu | Already supported in public CI on x64 VM |
-| aarch64 | Arm | CPU | Ubuntu | Arm Neoverse Processor Family: N1, V1, or V2 |
+| AArch64 | Arm | CPU | Ubuntu | Arm Neoverse Processor Family: N1, V1, or V2 |
 | Intel Data Center Max Series | Intel | GPU | Ubuntu | Or at least one from [Intel oneMKL supported list](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/oneapi-math-kernel-library-system-requirements.html) on Linux |
 | A100 or H100 | NVIDIA | GPU | Ubuntu | Or at least Compute Capability 7.5 or later (T4+), see [CUDA toolkit deprecated GPUs](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-architectures) |
 | MI210 | AMD | GPU | Ubuntu | Or at least one from [ROCm supported list](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html) |

--- a/project-infrastructure/project-ci-documentation.md
+++ b/project-infrastructure/project-ci-documentation.md
@@ -129,20 +129,21 @@ Support contact for CI:
 
 | Owner | Type | OS | Number | Active? | How to access logs |
 | --- | --- | --- | --- | --- | --- |
-| ? | ? | ? | ? | ? | ? |
+| GitHub	| CPU x86 | Ubuntu latest | N/A - GitHub-hosted runners | Yes | From workflow run |
 
 *Required Public CI Infrastruture Needed To Confidently Accept Contributions*
 
-| Instruction set architecture | Hardware Vendor | Processor Type | Operating System | 
-| --- | --- | --- | --- |
-| x86 | Intel | CPU | Ubuntu |
-| aarch64 | Arm | CPU | Ubuntu |
+| Instruction set architecture | Hardware Vendor | Processor Type | Operating System | Comment |
+| --- | --- | --- | --- | --- |
+| x86 | Intel | CPU | Ubuntu | Already supported in Public CI |
+| aarch64 | Arm | CPU | Ubuntu | Arm Neoverse Processor Family: N1, V1, or V2 |
+| Intel Data Center Max Series | Intel | GPU | Ubuntu | Or at least one from [Intel oneMKL supported list](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/oneapi-math-kernel-library-system-requirements.html) on Linux |
+| A100 or H100 | NVIDIA | GPU | Ubuntu | Or at least Compute Capability 7.5 or later (T4+), see [CUDA toolkit deprecated GPUs](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-architectures) |
+| MI210 | AMD | GPU | Ubuntu | Or at least one from [ROCm supported list](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html) |
+| x86 | Intel | CPU | Windows | Can be supported with GitHub-hosted runners, but they have not enough procesors for acceptable build time |
+| Intel Flex or Arch Series | Intel | GPU | Windows | Or at least one from [Intel oneMKL supported list](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/oneapi-math-kernel-library-system-requirements.html) on Windows |
 
-Software Versions
-
-CMake
-glibc
-...
+Software requiremenbts: [link](https://github.com/uxlfoundation/oneMath/tree/develop?tab=readme-ov-file#software-requirements)
 
 oneTBB 
 ------

--- a/project-infrastructure/project-ci-documentation.md
+++ b/project-infrastructure/project-ci-documentation.md
@@ -131,7 +131,7 @@ Support contact for CI:
 | --- | --- | --- | --- | --- | --- |
 | GitHub	| CPU x86 | Ubuntu latest | N/A - GitHub-hosted runners | Yes | From workflow run |
 
-*Required Public CI Infrastruture Needed To Confidently Accept Contributions*
+*Required Public CI Infrastructure Needed To Confidently Accept Contributions*
 
 | Instruction set architecture | Hardware Vendor | Processor Type | Operating System | Comment |
 | --- | --- | --- | --- | --- |
@@ -140,10 +140,10 @@ Support contact for CI:
 | Intel Data Center Max Series | Intel | GPU | Ubuntu | Or at least one from [Intel oneMKL supported list](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/oneapi-math-kernel-library-system-requirements.html) on Linux |
 | A100 or H100 | NVIDIA | GPU | Ubuntu | Or at least Compute Capability 7.5 or later (T4+), see [CUDA toolkit deprecated GPUs](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-architectures) |
 | MI210 | AMD | GPU | Ubuntu | Or at least one from [ROCm supported list](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html) |
-| x86 | Intel | CPU | Windows | Can be supported with GitHub-hosted runners, but they have not enough procesors for acceptable build time |
+| x86 | Intel | CPU | Windows | Can be supported with GitHub-hosted runners, but they have not enough processors for acceptable build time |
 | Intel Flex or Arch Series | Intel | GPU | Windows | Or at least one from [Intel oneMKL supported list](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/oneapi-math-kernel-library-system-requirements.html) on Windows |
 
-Software requiremenbts: [link](https://github.com/uxlfoundation/oneMath/tree/develop?tab=readme-ov-file#software-requirements)
+Software requirements: [link](https://github.com/uxlfoundation/oneMath/tree/develop?tab=readme-ov-file#software-requirements)
 
 oneTBB 
 ------

--- a/project-infrastructure/project-ci-documentation.md
+++ b/project-infrastructure/project-ci-documentation.md
@@ -122,8 +122,9 @@ glibc
 oneMath
 -------
 
-Representative: Maria Kraynyuk
-Support contact for CI:
+Representative: [Maria Kraynyuk](https://github.com/mkrainiuk)
+
+Support contact for CI: [Alexey Srednitsky](https://github.com/toxicscum)
 
 *Existing public CI*
 
@@ -135,12 +136,12 @@ Support contact for CI:
 
 | Instruction set architecture | Hardware Vendor | Processor Type | Operating System | Comment |
 | --- | --- | --- | --- | --- |
-| x86 | Intel | CPU | Ubuntu | Already supported in Public CI |
+| x86 | Intel/AMD | CPU | Ubuntu | Already supported in public CI on x64 VM |
 | aarch64 | Arm | CPU | Ubuntu | Arm Neoverse Processor Family: N1, V1, or V2 |
 | Intel Data Center Max Series | Intel | GPU | Ubuntu | Or at least one from [Intel oneMKL supported list](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/oneapi-math-kernel-library-system-requirements.html) on Linux |
 | A100 or H100 | NVIDIA | GPU | Ubuntu | Or at least Compute Capability 7.5 or later (T4+), see [CUDA toolkit deprecated GPUs](https://docs.nvidia.com/cuda/cuda-toolkit-release-notes/index.html#deprecated-architectures) |
 | MI210 | AMD | GPU | Ubuntu | Or at least one from [ROCm supported list](https://rocm.docs.amd.com/projects/install-on-linux/en/latest/reference/system-requirements.html) |
-| x86 | Intel | CPU | Windows | Can be supported with GitHub-hosted runners, but they have not enough processors for acceptable build time |
+| x86 | Intel/AMD | CPU | Windows | Can be supported with GitHub-hosted runners, but they have not enough processors for acceptable build time |
 | Intel Flex or Arch Series | Intel | GPU | Windows | Or at least one from [Intel oneMKL supported list](https://www.intel.com/content/www/us/en/developer/articles/system-requirements/oneapi-math-kernel-library-system-requirements.html) on Windows |
 
 Software requirements: [link](https://github.com/uxlfoundation/oneMath/tree/develop?tab=readme-ov-file#software-requirements)


### PR DESCRIPTION
The PR is adding information about oneMKL existing and required resources for public CI

Fixes https://github.com/uxlfoundation/open-source-working-group/issues/211 