### PR TITLE
Correct the name of the Slack channel for the open source working group.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,7 +7,7 @@ The group charter is currently being defined and agreed.
 
 During 2024 the group will be focusing on ensuring that the community have a frictionless experience when contributing to the UXL Foundation projects.
 
-`Join the Slack`_ channel "open-source-wg" to participate in the discussions.
+`Join the Slack`_ channel "wg-open-source" to participate in the discussions.
 
 * `Meeting Notes`_
 


### PR DESCRIPTION
The name of the Slack channel used for the UXL Open Source working group doesn't match what's in the README.  Updating the README with the correct channel name.